### PR TITLE
Prefer LTS Node version over unstable one

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "engines": {
-    "node": ">=13"
+    "node": ">=12.17"
   },
   "scripts": {
     "test": "mocha \"./src/**/*.test.js\"",


### PR DESCRIPTION
Support for modules without `--experimental-modules` has been [downported to v12.17](https://nodejs.org/en/blog/release/v12.17.0/).