### PR TITLE
Improve automated commit messages

### DIFF
--- a/src/history/persistor.js
+++ b/src/history/persistor.js
@@ -24,12 +24,12 @@ export const SANITIZED_DIRECTORY = `${ROOT_DIRECTORY}/sanitized`;
 export async function persist({ serviceProviderId, policyType, fileContent, relatedRawCommitSha }) {
   const isSanitized = !!relatedRawCommitSha;
   const filePath = await save({ serviceProviderId, policyType, fileContent, isSanitized });
-  let message = `Update ${isSanitized ? 'sanitized' : 'raw'} ${serviceProviderId} ${DOCUMENTS_TYPES[policyType].name} document`;
+  let message = `Update ${isSanitized ? '' : 'raw '}${serviceProviderId} ${DOCUMENTS_TYPES[policyType].name}`;
 
   if (relatedRawCommitSha) {
     message += `
 
-Find related raw file changes in this commit ${relatedRawCommitSha}`;
+Find related raw file changes in commit ${relatedRawCommitSha}`;
   }
 
   const sha = await commit(filePath, message);


### PR DESCRIPTION
- Remove redundant “document” mention.
- Remove “sanitized” mention to reduce noise when end user navigates history.
- Fix grammar.

I would have liked to change the message when a file is added for the first time (“Start tracking…”), but could not find a fast way to do it :wink: