### PR TITLE
Convert HTML tables to Markdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2303,6 +2303,11 @@
         "jsdom": "^16.2.0"
       }
     },
+    "turndown-plugin-gfm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz",
+      "integrity": "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg=="
+    },
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1201,6 +1201,11 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
+    "joplin-turndown-plugin-gfm": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/joplin-turndown-plugin-gfm/-/joplin-turndown-plugin-gfm-1.0.12.tgz",
+      "integrity": "sha512-qL4+1iycQjZ1fs8zk3jSRk7cg3ROBUHk7GKtiLAQLFzLPKErnILUvz5DLszSQvz3s1sTjPbywLDISVUtBY6HaA=="
+    },
     "js-yaml": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
@@ -2302,11 +2307,6 @@
       "requires": {
         "jsdom": "^16.2.0"
       }
-    },
-    "turndown-plugin-gfm": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz",
-      "integrity": "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg=="
     },
     "tweetnacl": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "node-schedule": "^1.3.2",
     "sib-api-v3-sdk": "^7.2.3",
     "simple-git": "^2.6.0",
-    "turndown": "^6.0.0"
+    "turndown": "^6.0.0",
+    "turndown-plugin-gfm": "^1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,12 +42,12 @@
     "dotenv": "^8.2.0",
     "http-proxy-agent": "^4.0.1",
     "https-proxy-agent": "^5.0.0",
+    "joplin-turndown-plugin-gfm": "^1.0.12",
     "jsdom": "^16.2.2",
     "node-fetch": "^2.6.0",
     "node-schedule": "^1.3.2",
     "sib-api-v3-sdk": "^7.2.3",
     "simple-git": "^2.6.0",
-    "turndown": "^6.0.0",
-    "turndown-plugin-gfm": "^1.0.2"
+    "turndown": "^6.0.0"
   }
 }

--- a/src/filter/index.js
+++ b/src/filter/index.js
@@ -1,5 +1,5 @@
 import TurndownService from 'turndown';
-import turndownPluginGithubFlavouredMarkdown from 'turndown-plugin-gfm';
+import turndownPluginGithubFlavouredMarkdown from 'joplin-turndown-plugin-gfm';
 import jsdom from 'jsdom';
 
 const { JSDOM } = jsdom;

--- a/src/filter/index.js
+++ b/src/filter/index.js
@@ -1,8 +1,10 @@
 import TurndownService from 'turndown';
+import turndownPluginGithubFlavouredMarkdown from 'turndown-plugin-gfm';
 import jsdom from 'jsdom';
 
 const { JSDOM } = jsdom;
 const turndownService = new TurndownService();
+turndownService.use(turndownPluginGithubFlavouredMarkdown.gfm);
 
 
 export default async function filter(content, selector, filterNames, filterFunctions) {


### PR DESCRIPTION
The following services contain at least one `<table>`. They have a checkbox associated with them that should be checked when the result of running the filters on them has been double-checked.

- [x] AskFM
- [x] Badoo
- [x] deviantART
- [x] MouthShut
- [x] StackOverflow
- [x] WeChat
- [x] Yelp