### PR TITLE
Number MySpace lists correctly

### DIFF
--- a/services/Myspace.filters.js
+++ b/services/Myspace.filters.js
@@ -1,0 +1,6 @@
+export function numberListCorrectly(document) {
+    document.querySelectorAll('ol')
+        .forEach(listToClean => Array.from(listToClean.children)
+            .filter(element => element.tagName != 'LI')
+            .map(element => element.remove()));
+}

--- a/services/Myspace.filters.js
+++ b/services/Myspace.filters.js
@@ -1,6 +1,6 @@
 export function numberListCorrectly(document) {
-    document.querySelectorAll('ol')
-        .forEach(listToClean => Array.from(listToClean.children)
-            .filter(element => element.tagName != 'LI')
-            .map(element => element.remove()));
+  document.querySelectorAll('ol')
+    .forEach(listToClean => Array.from(listToClean.children)
+      .filter(element => element.tagName != 'LI')
+      .map(element => element.remove()));
 }

--- a/services/Myspace.json
+++ b/services/Myspace.json
@@ -1,19 +1,19 @@
 {
-    "name": "Myspace",
-    "documents": {
-        "tos": {
-            "location": "https://myspace.com/pages/terms",
-            "contentSelector": "#nms_legal",
-            "filters": [
-                "numberListCorrectly"
-            ]
-        },
-        "privacy": {
-            "location": "https://myspace.com/pages/eeaprivacy",
-            "contentSelector": "#nms_legal",
-            "filters": [
-                "numberListCorrectly"
-            ]
-        }
+  "name": "Myspace",
+  "documents": {
+    "tos": {
+      "location": "https://myspace.com/pages/terms",
+      "contentSelector": "#nms_legal",
+      "filters": [
+        "numberListCorrectly"
+      ]
+    },
+    "privacy": {
+      "location": "https://myspace.com/pages/eeaprivacy",
+      "contentSelector": "#nms_legal",
+      "filters": [
+        "numberListCorrectly"
+      ]
     }
+  }
 }

--- a/services/Myspace.json
+++ b/services/Myspace.json
@@ -3,11 +3,17 @@
     "documents": {
         "tos": {
             "location": "https://myspace.com/pages/terms",
-            "contentSelector": "#nms_legal"
+            "contentSelector": "#nms_legal",
+            "filters": [
+                "numberListCorrectly"
+            ]
         },
         "privacy": {
             "location": "https://myspace.com/pages/eeaprivacy",
-            "contentSelector": "#nms_legal"
+            "contentSelector": "#nms_legal",
+            "filters": [
+                "numberListCorrectly"
+            ]
         }
     }
 }


### PR DESCRIPTION
In MySpace documents, lists encapsulated in <ol> tags were badly numbered because invisible tag which were not <li> tags were disrupting numbering. This PR solve the issue.