### PR TITLE
Start to follow GoogleAds

### DIFF
--- a/services/GoogleAdsController.json
+++ b/services/GoogleAdsController.json
@@ -1,0 +1,25 @@
+{
+  "name": "GoogleAdsController",
+  "documents": {
+    "tos": {
+      "fetch": "https://privacy.google.com/businesses/controllerterms/",
+      "select": ".ads-controller"
+    },
+    "cookiesPolicy": {
+      "fetch": "https://policies.google.com/technologies/ads",
+      "select": "div[role=article]"
+    },
+    "userConsentPolicy": {
+      "fetch": "https://www.google.com/about/company/user-consent-policy/",
+      "select": ".page-section" 
+    },
+    "servicesList": {
+      "fetch": "https://privacy.google.com/businesses/adsservices/",
+      "select": ".ads-controller",
+      "remove": {
+      	"startBefore": "h2:nth-of-type(2)",
+      	"endBefore":"#previous-versions"
+      }
+    }
+  }
+}

--- a/services/GoogleAdsProcessor.json
+++ b/services/GoogleAdsProcessor.json
@@ -1,0 +1,25 @@
+{
+  "name": "GoogleAdsProcessor",
+  "documents": {
+    "tos": {
+      "fetch": "https://privacy.google.com/businesses/processorterms/",
+      "select": ".ads-controller"
+    },
+    "cookiesPolicy": {
+      "fetch": "https://policies.google.com/technologies/ads",
+      "select": "div[role=article]"
+    },
+    "userConsentPolicy": {
+      "fetch": "https://www.google.com/about/company/user-consent-policy/",
+      "select": ".page-section" 
+    },
+    "servicesList": {
+      "fetch": "https://privacy.google.com/businesses/adsservices/",
+      "select": ".ads-controller",
+      "remove": {
+        "startBefore": "h2:nth-of-type(1)",
+        "endBefore":"h2:nth-of-type(2)"
+      }
+    }
+  }
+}

--- a/services/GoogleMeasurementController.json
+++ b/services/GoogleMeasurementController.json
@@ -1,0 +1,17 @@
+{
+  "name": "GoogleMeasurementController",
+  "documents": {
+    "tos": {
+      "fetch": "https://support.google.com/analytics/answer/9012600",
+      "select": ".article-container"
+    },
+    "cookiesPolicy": {
+      "fetch": "https://policies.google.com/technologies/ads",
+      "select": "div[role=article]"
+    },
+    "userConsentPolicy": {
+      "fetch": "https://www.google.com/about/company/user-consent-policy/",
+      "select": ".page-section" 
+    }
+  }
+}

--- a/src/types.js
+++ b/src/types.js
@@ -58,5 +58,13 @@ export const TYPES = {
   inAppPurchasesPolicy: {
     name: 'In App Purchases Policy',
     fileName: 'in_app_purchases_policy'
+  },
+  userConsentPolicy: {
+    name: 'User Consent Policy',
+    fileName: 'user_consent_policy'
+  },
+  servicesList: {
+    name: 'List of Services',
+    fileName: 'services_list'
   }
 };


### PR DESCRIPTION
This PR isn't ready yet and I suggest that we discuss the way we would like to handle GoogleAds.

To summarize : following Schrems II (invalidation of Privacy Shield), Google announced that they would therefore be updating those three documents tomorrow :  [Google Ads Data Processing Terms](https://privacy.google.com/businesses/processorterms/), [Google Ads Controller-Controller Data Protection Terms](https://privacy.google.com/businesses/controllerterms/) and [Google Measurement Controller-Controller Data Protection Terms](https://support.google.com/analytics/answer/9012600?hl=en). 
As a consequence we would like to follow them since the changes will surely be enlightening. 

Yet I encountered some issues that emphasize our recent questioning about "What is a service ?" "How to handle parent company terms ?"etc.

Each document is only relevant for some specific services part of Google Ads (see https://privacy.google.com/businesses/adsservices/ and https://support.google.com/analytics/answer/9012600 Definitions > Measurement Services). Do we want to follow each service (meaning separating Google Analytics from Google Analytics 360 and Google Analytics for Firebase, and Google Ad Manager, Google AdMob...), while duplicating these documents in the same way we use 'tosParent' ? Do we want to aggregate some of them in a Google Ads service ? 
The more I think of it, the more I'm doubting whether our "service-centered conception" is adequate. Legally binding documents seems to be organized in **layers**, from general (Google privacy policy), to aggregated services (Google Ads Data Processing Terms), to service-centered (for instance https://marketingplatform.google.com/about/analytics/terms/us/). 

Anyway, here I chose to aggregate services following documents definition. I also added two complementary documents : Google Ads Cookie policy, and [EU User Consent Policy] (https://www.google.com/about/company/user-consent-policy/) (which is a new document type). I also chose to keep the (services list document) (https://privacy.google.com/businesses/adsservices/) in another new document type. Obviously it is an arbitrary choice and feel free to discuss it ! :slightly_smiling_face: 