### PR TITLE
Import service declarations from tosback2

### DIFF
--- a/scripts/tosback-import.js
+++ b/scripts/tosback-import.js
@@ -124,8 +124,30 @@ async function parseFile(filename) {
 }
 
 function toPascalCase(str) {
-  const lowerCase = str.toLowerCase();
-  return str[0].toUpperCase() + lowerCase.substring(1);
+  const parts = str.split(' ');
+  const candidate = parts.map(part => {
+    const lowerCase = part.toLowerCase().replace(/[^a-zA-Z0-9]/g, '');
+    return part[0].toUpperCase() + lowerCase.substring(1);
+  }).join('');
+  return {
+    Att: 'ATT',
+    Bbc: 'BBC',
+    Discordapp: 'DiscordApp',
+    Duckduckgo: 'DuckDuckGo',
+    Foxnews: 'FoxNews',
+    Github: 'GitHub',
+    Live: 'MicrosoftLive',
+    Msn: 'MSN',
+    Phpbb: 'phpBB',
+    Plus: 'GooglePlus',
+    Microsoftstore: 'MicrosoftStore',
+    Play: 'GooglePlayStore', // note this is an exception in https://github.com/ambanum/CGUs/issues/106#issue-680943515
+    W3schools: 'W3Schools',
+    Wikimediafoundation: 'WikimediaFoundation',
+    Wordpress: 'WordPress',
+    Xing: 'XING',
+    Youtube: 'YouTube'
+  }[candidate] || candidate;
 }
 
 function toType(str) {
@@ -204,6 +226,10 @@ async function processTosback2(importedFrom, imported) {
     imported.sitename.docname = [ imported.sitename.docname ];
   }
   const serviceName = toPascalCase(imported.sitename.name.split('.')[0]);
+  if (!imported.sitename.docname[0].url.reviewed) {
+    console.log('focusing on crawl_reviewed, skipping the rest');
+    return;
+  }
   const promises = imported.sitename.docname.map(async docnameObj => processWhenReady(serviceName, docnameObj.name, docnameObj.url.name, docnameObj.url.xpath, importedFrom).catch(e => {
     console.log('Could not process', serviceName, docnameObj.name, docnameObj.url.name, docnameObj.url.xpath, importedFrom, e.message);
   }));
@@ -285,4 +311,4 @@ async function run(includeXml, includePsql) {
 }
 
 // Edit this line to run the Tosback / ToS;DR import(s) you want:
-run(false, true);
+run(true, false);

--- a/scripts/validation/validate.js
+++ b/scripts/validation/validate.js
@@ -50,7 +50,7 @@ let serviceDeclarations;
                 let filteredContent;
 
                 it('has fetchable URL', async function () {
-                  this.timeout(10000);
+                  this.timeout(30000);
 
                   const { fetch: location } = service.documents[type];
                   content = await fetch(location);
@@ -92,7 +92,7 @@ let serviceDeclarations;
                       this.skip();
                     }
 
-                    this.timeout(10000);
+                    this.timeout(30000);
 
                     const { fetch: location } = service.documents[type];
                     const secondContent = await fetch(location);

--- a/services/ATT.json
+++ b/services/ATT.json
@@ -1,0 +1,10 @@
+{
+  "name": "ATT",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/att.com.xml",
+  "documents": {
+    "Terms of Service": {
+      "fetch": "https://www.att.com/legal/terms.aup.html",
+      "select": "div#termsofservices"
+    }
+  }
+}

--- a/services/Amazon.json
+++ b/services/Amazon.json
@@ -1,0 +1,10 @@
+{
+  "name": "Amazon",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/amazon.com.xml",
+  "documents": {
+    "Terms of Service": {
+      "fetch": "https://www.amazon.com/gp/help/customer/display.html?nodeId=508088",
+      "select": "div.help-content"
+    }
+  }
+}

--- a/services/Android.json
+++ b/services/Android.json
@@ -1,0 +1,10 @@
+{
+  "name": "Android",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/android.com.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://policies.google.com/privacy",
+      "select": "div[role=\"article\"]"
+    }
+  }
+}

--- a/services/Apple.json
+++ b/services/Apple.json
@@ -4,6 +4,10 @@
     "Privacy Policy": {
       "fetch": "https://www.apple.com/legal/privacy/en-ww/",
       "select": "main"
+    },
+    "Terms of Service": {
+      "fetch": "http://www.apple.com/legal/internet-services/terms/site.html",
+      "select": "main.main"
     }
   }
 }

--- a/services/AskFM.json
+++ b/services/AskFM.json
@@ -2,11 +2,11 @@
   "name": "AskFM",
   "documents": {
     "Terms of Service": {
-      "fetch": "https://about.ask.fm/legal/en/terms.html",
+      "fetch": "https://ask.fm/docs/terms_of_use/?lang=en",
       "select": "section.container"
     },
     "Privacy Policy": {
-      "fetch": "https://about.ask.fm/legal/en/privacy.html",
+      "fetch": "https://ask.fm/docs/privacy_policy/?lang=en",
       "select": "section.container"
     }
   }

--- a/services/BBC.json
+++ b/services/BBC.json
@@ -1,0 +1,10 @@
+{
+  "name": "BBC",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/bbc.com.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "http://www.bbc.com/usingthebbc/privacy-policy/",
+      "select": "div.gel-wrap"
+    }
+  }
+}

--- a/services/Blizzard.json
+++ b/services/Blizzard.json
@@ -1,0 +1,10 @@
+{
+  "name": "Blizzard",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/blizzard.com.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://www.blizzard.com/en-us/legal/a4380ee5-5c8d-4e3b-83b7-ea26d01a9918/blizzard-entertainment-online-privacy-policy",
+      "select": "div.legalDocContent"
+    }
+  }
+}

--- a/services/Blogger.json
+++ b/services/Blogger.json
@@ -1,0 +1,14 @@
+{
+  "name": "Blogger",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/blogger.com.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://policies.google.com/privacy",
+      "select": "div[role=\"article\"]"
+    },
+    "Terms of Service": {
+      "fetch": "https://policies.google.com/terms",
+      "select": "div[role=\"article\"]"
+    }
+  }
+}

--- a/services/Blogspot.json
+++ b/services/Blogspot.json
@@ -1,0 +1,14 @@
+{
+  "name": "Blogspot",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/blogspot.com.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://policies.google.com/privacy",
+      "select": "div[role=\"article\"]"
+    },
+    "Terms of Service": {
+      "fetch": "https://policies.google.com/terms",
+      "select": "div[role=\"article\"]"
+    }
+  }
+}

--- a/services/Cloudant.json
+++ b/services/Cloudant.json
@@ -1,0 +1,14 @@
+{
+  "name": "Cloudant",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/cloudant.com.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://www.ibm.com/privacy/us/en/",
+      "select": "div#ibm-content-main"
+    },
+    "Terms of Service": {
+      "fetch": "https://www.ibm.com/legal/us/en/",
+      "select": "div#ibm-content-main"
+    }
+  }
+}

--- a/services/Couchsurfing.json
+++ b/services/Couchsurfing.json
@@ -1,0 +1,10 @@
+{
+  "name": "Couchsurfing",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/couchsurfing.org.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "http://about.couchsurfing.com/privacy-policy/",
+      "select": "section#privacy-policy"
+    }
+  }
+}

--- a/services/Coursera.json
+++ b/services/Coursera.json
@@ -1,0 +1,10 @@
+{
+  "name": "Coursera",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/coursera.org.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://www.coursera.org/about/privacy",
+      "select": "div.coursera-tos"
+    }
+  }
+}

--- a/services/Dictionary.json
+++ b/services/Dictionary.json
@@ -1,0 +1,10 @@
+{
+  "name": "Dictionary",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/dictionary.com.xml",
+  "documents": {
+    "Terms of Service": {
+      "fetch": "http://www.dictionary.com/e/terms/",
+      "select": "article"
+    }
+  }
+}

--- a/services/DiscordApp.json
+++ b/services/DiscordApp.json
@@ -1,0 +1,10 @@
+{
+  "name": "DiscordApp",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/discordapp.com.xml",
+  "documents": {
+    "Terms of Service": {
+      "fetch": "https://discordapp.com/terms",
+      "select": "body"
+    }
+  }
+}

--- a/services/Disqus.json
+++ b/services/Disqus.json
@@ -1,0 +1,14 @@
+{
+  "name": "Disqus",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/disqus.com.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://help.disqus.com/terms-and-policies/disqus-privacy-policy",
+      "select": "article"
+    },
+    "Terms of Service": {
+      "fetch": "https://help.disqus.com/terms-and-policies/terms-of-service",
+      "select": "article"
+    }
+  }
+}

--- a/services/DuckDuckGo.json
+++ b/services/DuckDuckGo.json
@@ -1,0 +1,10 @@
+{
+  "name": "DuckDuckGo",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/duckduckgo.com.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://duckduckgo.com/privacy",
+      "select": "div#content_wrapper"
+    }
+  }
+}

--- a/services/Evernote.json
+++ b/services/Evernote.json
@@ -1,0 +1,14 @@
+{
+  "name": "Evernote",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/evernote.com.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://evernote.com/privacy/policy",
+      "select": "div.content-container"
+    },
+    "Terms of Service": {
+      "fetch": "https://evernote.com/legal/terms-of-service",
+      "select": "div.content-container"
+    }
+  }
+}

--- a/services/Finance.json
+++ b/services/Finance.json
@@ -1,0 +1,10 @@
+{
+  "name": "Finance",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/finance.yahoo.com.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://policies.oath.com/us/en/oath/privacy/index.html",
+      "select": "main#site-main"
+    }
+  }
+}

--- a/services/Flickr.json
+++ b/services/Flickr.json
@@ -8,6 +8,10 @@
     "Privacy Policy": {
       "fetch": "https://www.flickr.com/help/privacy/",
       "select": ".help-page-container"
+    },
+    "Community Guidelines": {
+      "fetch": "http://www.flickr.com/help/guidelines/",
+      "select": "div#content"
     }
   }
 }

--- a/services/Forums.json
+++ b/services/Forums.json
@@ -1,0 +1,10 @@
+{
+  "name": "Forums",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/forums.informe.com.xml",
+  "documents": {
+    "Terms of Service": {
+      "fetch": "http://forums.informe.com/TermsOfService.html",
+      "select": "div#content"
+    }
+  }
+}

--- a/services/FoxNews.json
+++ b/services/FoxNews.json
@@ -1,0 +1,14 @@
+{
+  "name": "FoxNews",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/foxnews.com.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://www.foxnews.com/privacy-policy",
+      "select": "section.privacy-policy"
+    },
+    "Closed Captioning Policy": {
+      "fetch": "https://www.foxnews.com/closed-captioning",
+      "select": "div.content"
+    }
+  }
+}

--- a/services/GitHub.json
+++ b/services/GitHub.json
@@ -1,0 +1,14 @@
+{
+  "name": "GitHub",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/github.com.xml",
+  "documents": {
+    "Terms of Service": {
+      "fetch": "https://help.github.com/en/articles/github-terms-of-service",
+      "select": "main"
+    },
+    "Privacy Policy": {
+      "fetch": "https://help.github.com/en/articles/github-privacy-statement",
+      "select": "main"
+    }
+  }
+}

--- a/services/Gmail.json
+++ b/services/Gmail.json
@@ -1,0 +1,10 @@
+{
+  "name": "Gmail",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/gmail.com.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://policies.google.com/privacy",
+      "select": "div[role=\"article\"]"
+    }
+  }
+}

--- a/services/GooglePlus.json
+++ b/services/GooglePlus.json
@@ -1,0 +1,10 @@
+{
+  "name": "GooglePlus",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/plus.google.com.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://policies.google.com/privacy",
+      "select": "div[role=\"article\"]"
+    }
+  }
+}

--- a/services/Grammarly.json
+++ b/services/Grammarly.json
@@ -1,0 +1,14 @@
+{
+  "name": "Grammarly",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/grammarly.com.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://www.grammarly.com/privacy-policy",
+      "select": "div#page"
+    },
+    "Terms of Service": {
+      "fetch": "https://www.grammarly.com/terms",
+      "select": "div#page"
+    }
+  }
+}

--- a/services/Habbo.json
+++ b/services/Habbo.json
@@ -1,0 +1,14 @@
+{
+  "name": "Habbo",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/habbo.com.xml",
+  "documents": {
+    "Terms of Service": {
+      "fetch": "https://help.habbo.com/hc/en-us/articles/221644728",
+      "select": "div.content-body.article-body"
+    },
+    "Privacy Policy": {
+      "fetch": "https://help.habbo.com/hc/en-us/articles/221644748",
+      "select": "div.content-body.article-body"
+    }
+  }
+}

--- a/services/Imgur.json
+++ b/services/Imgur.json
@@ -1,0 +1,10 @@
+{
+  "name": "Imgur",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/imgur.com.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "http://imgur.com/privacy",
+      "select": "div.text-content.privacy"
+    }
+  }
+}

--- a/services/Lastpass.json
+++ b/services/Lastpass.json
@@ -1,0 +1,10 @@
+{
+  "name": "Lastpass",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/lastpass.com.xml",
+  "documents": {
+    "Terms of Service": {
+      "fetch": "https://www.logmeininc.com/legal/terms-and-conditions",
+      "select": "div.text-block"
+    }
+  }
+}

--- a/services/MSN.json
+++ b/services/MSN.json
@@ -1,0 +1,14 @@
+{
+  "name": "MSN",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/msn.com.xml",
+  "documents": {
+    "Terms of Service": {
+      "fetch": "https://www.microsoft.com/en-us/servicesagreement/",
+      "select": "div.row-fluid.grid-container.mscom-grid-container"
+    },
+    "Privacy Policy": {
+      "fetch": "https://privacy.microsoft.com/en-us/PrivacyStatement",
+      "select": "div[style=\"background-color:white\"]"
+    }
+  }
+}

--- a/services/Microsoft.json
+++ b/services/Microsoft.json
@@ -1,0 +1,14 @@
+{
+  "name": "Microsoft",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/microsoft.com.xml",
+  "documents": {
+    "Terms of Service": {
+      "fetch": "https://www.microsoft.com/en-us/servicesagreement",
+      "select": "div.CSPvNext"
+    },
+    "Privacy Policy": {
+      "fetch": "https://privacy.microsoft.com/en-us/privacystatement",
+      "select": "div[style=\"background-color:white\"] > div"
+    }
+  }
+}

--- a/services/MicrosoftLive.json
+++ b/services/MicrosoftLive.json
@@ -1,0 +1,14 @@
+{
+  "name": "MicrosoftLive",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/live.com.xml",
+  "documents": {
+    "Terms of Service": {
+      "fetch": "https://www.microsoft.com/en-us/servicesagreement/",
+      "select": "div.row-fluid.grid-container.mscom-grid-container"
+    },
+    "Privacy Policy": {
+      "fetch": "https://privacy.microsoft.com/en-us/PrivacyStatement",
+      "select": "div[style=\"background-color:white\"]"
+    }
+  }
+}

--- a/services/MicrosoftStore.json
+++ b/services/MicrosoftStore.json
@@ -1,0 +1,14 @@
+{
+  "name": "MicrosoftStore",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/microsoftstore.com.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://privacy.microsoft.com/en-us/privacystatement",
+      "select": "div[style=\"background-color:white\"] > div"
+    },
+    "Terms of Service": {
+      "fetch": "https://www.microsoft.com/en-us/store/b/terms-of-sale",
+      "select": "section#mainArea"
+    }
+  }
+}

--- a/services/Nabble.json
+++ b/services/Nabble.json
@@ -1,0 +1,14 @@
+{
+  "name": "Nabble",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/nabble.com.xml",
+  "documents": {
+    "Terms of Service": {
+      "fetch": "http://www.nabble.com/Terms.jtp",
+      "select": "div.terms"
+    },
+    "Privacy Policy": {
+      "fetch": "http://www.nabble.com/PrivacyPolicy.jtp",
+      "select": "div.terms"
+    }
+  }
+}

--- a/services/Netflix.json
+++ b/services/Netflix.json
@@ -1,0 +1,10 @@
+{
+  "name": "Netflix",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/netflix.com.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://help.netflix.com/en/legal/privacy",
+      "select": "section.kb-article.kb-article-variant.gradient"
+    }
+  }
+}

--- a/services/Packagetrackr.json
+++ b/services/Packagetrackr.json
@@ -1,0 +1,14 @@
+{
+  "name": "Packagetrackr",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/packagetrackr.com.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://www.packagetrackr.com/privacy",
+      "select": "div#content"
+    },
+    "Terms of Service": {
+      "fetch": "https://www.packagetrackr.com/tos",
+      "select": "div#content"
+    }
+  }
+}

--- a/services/Researchgate.json
+++ b/services/Researchgate.json
@@ -1,0 +1,10 @@
+{
+  "name": "Researchgate",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/researchgate.net.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://www.researchgate.net/privacy-policy",
+      "select": "div.privacy-policy"
+    }
+  }
+}

--- a/services/Runescape.json
+++ b/services/Runescape.json
@@ -1,0 +1,10 @@
+{
+  "name": "Runescape",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/runescape.com.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://www.jagex.com/en-GB/terms/privacy",
+      "select": "div.c-copy-block__content"
+    }
+  }
+}

--- a/services/Seenthis.json
+++ b/services/Seenthis.json
@@ -1,0 +1,10 @@
+{
+  "name": "Seenthis",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/seenthis.net.xml",
+  "documents": {
+    "Copyright Claims Policy": {
+      "fetch": "http://seenthis.net/fran%C3%A7ais/mentions/article/propri%C3%A9t%C3%A9-intellectuelle",
+      "select": "div#texte_article"
+    }
+  }
+}

--- a/services/Sonic.json
+++ b/services/Sonic.json
@@ -1,0 +1,10 @@
+{
+  "name": "Sonic",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/sonic.com.xml",
+  "documents": {
+    "Terms of Service": {
+      "fetch": "https://help.sonic.com/hc/en-us/articles/235963988-Sonic-net-Policies",
+      "select": "div.article-body"
+    }
+  }
+}

--- a/services/Spotify.json
+++ b/services/Spotify.json
@@ -1,0 +1,14 @@
+{
+  "name": "Spotify",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/spotify.com.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://www.spotify.com/us/legal/privacy-policy/",
+      "select": "div#content-main"
+    },
+    "Terms of Service": {
+      "fetch": "https://www.spotify.com/us/legal/end-user-agreement/",
+      "select": "div#content-main"
+    }
+  }
+}

--- a/services/Steampowered.json
+++ b/services/Steampowered.json
@@ -1,0 +1,10 @@
+{
+  "name": "Steampowered",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/steampowered.com.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://store.steampowered.com/privacy_agreement/",
+      "select": "div#newsColumn"
+    }
+  }
+}

--- a/services/Tumblr.json
+++ b/services/Tumblr.json
@@ -1,0 +1,14 @@
+{
+  "name": "Tumblr",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/tumblr.com.xml",
+  "documents": {
+    "Terms of Service": {
+      "fetch": "https://www.tumblr.com/policy/en/terms-of-service",
+      "select": "div#left_column"
+    },
+    "Privacy Policy": {
+      "fetch": "https://www.tumblr.com/privacy/en",
+      "select": "div#left_column"
+    }
+  }
+}

--- a/services/Twitpic.json
+++ b/services/Twitpic.json
@@ -1,0 +1,14 @@
+{
+  "name": "Twitpic",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/twitpic.com.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://twitter.com/en/privacy",
+      "select": "main"
+    },
+    "Terms of Service": {
+      "fetch": "https://twitter.com/en/tos",
+      "select": "main"
+    }
+  }
+}

--- a/services/Verizon.json
+++ b/services/Verizon.json
@@ -1,0 +1,14 @@
+{
+  "name": "Verizon",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/verizon.com.xml",
+  "documents": {
+    "Terms of Service": {
+      "fetch": "https://www.verizonwireless.com/legal/notices/customer-agreement/",
+      "select": "div[data-ck=\"LEGAL_DISCLAIMER_CUSTOMER_AGREEMENT\"]"
+    },
+    "Privacy Policy": {
+      "fetch": "https://www.verizon.com/about/privacy/gizmo-privacy-policy",
+      "select": "main"
+    }
+  }
+}

--- a/services/W3Schools.json
+++ b/services/W3Schools.json
@@ -1,0 +1,10 @@
+{
+  "name": "W3Schools",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/w3schools.com.xml",
+  "documents": {
+    "Terms of Service": {
+      "fetch": "https://www.w3schools.com/about/about_copyright.asp",
+      "select": "#main"
+    }
+  }
+}

--- a/services/WhatsApp.json
+++ b/services/WhatsApp.json
@@ -1,13 +1,10 @@
 {
-  "name": "WhatsApp",
+  "name": "Whatsapp",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/whatsapp.com.xml",
   "documents": {
     "Terms of Service": {
-      "fetch": "https://www.whatsapp.com/legal?eea=1",
-      "select": "div._-pj:nth-child(3)"
-    },
-    "Privacy Policy": {
-      "fetch": "https://www.whatsapp.com/legal?eea=1",
-      "select": "div._-pj:nth-child(4)"
+      "fetch": "https://www.whatsapp.com/legal?eea=0",
+      "select": "div._2z9-"
     }
   }
 }

--- a/services/WikimediaFoundation.json
+++ b/services/WikimediaFoundation.json
@@ -1,0 +1,10 @@
+{
+  "name": "WikimediaFoundation",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/wikimediafoundation.org.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://wikimediafoundation.org/wiki/Privacy_policy",
+      "select": "#mw-content-text"
+    }
+  }
+}

--- a/services/Wikipedia.json
+++ b/services/Wikipedia.json
@@ -1,0 +1,10 @@
+{
+  "name": "Wikipedia",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/wikipedia.org.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://wikimediafoundation.org/wiki/Privacy_policy",
+      "select": "#mw-content-text"
+    }
+  }
+}

--- a/services/WordPress.json
+++ b/services/WordPress.json
@@ -1,0 +1,10 @@
+{
+  "name": "WordPress",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/wordpress.com.xml",
+  "documents": {
+    "Terms of Service": {
+      "fetch": "http://en.wordpress.com/tos/",
+      "select": "div.pagebody"
+    }
+  }
+}

--- a/services/Wordfeud.json
+++ b/services/Wordfeud.json
@@ -1,0 +1,14 @@
+{
+  "name": "Wordfeud",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/wordfeud.com.xml",
+  "documents": {
+    "Terms of Service": {
+      "fetch": "http://wordfeud.com/tos/",
+      "select": "body"
+    },
+    "Privacy Policy": {
+      "fetch": "http://wordfeud.com/privacy/",
+      "select": "body"
+    }
+  }
+}

--- a/services/XING.json
+++ b/services/XING.json
@@ -1,0 +1,10 @@
+{
+  "name": "XING",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/xing.com.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://privacy.xing.com/en/privacy-policy/printable-version",
+      "select": "div.data-protection-long-version-content"
+    }
+  }
+}

--- a/services/Xfinity.json
+++ b/services/Xfinity.json
@@ -1,0 +1,10 @@
+{
+  "name": "Xfinity",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/xfinity.com.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://www.xfinity.com/Corporate/Customers/Policies/CustomerPrivacy",
+      "select": "main[role=\"main\"]"
+    }
+  }
+}

--- a/services/Yahoo.json
+++ b/services/Yahoo.json
@@ -1,0 +1,14 @@
+{
+  "name": "Yahoo",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/yahoo.com.xml",
+  "documents": {
+    "Terms of Service": {
+      "fetch": "https://policies.oath.com/us/en/oath/terms/otos/index.html",
+      "select": "main#site-main"
+    },
+    "Privacy Policy": {
+      "fetch": "https://policies.oath.com/us/en/oath/privacy/index.html",
+      "select": "main#site-main"
+    }
+  }
+}

--- a/services/YouTube.json
+++ b/services/YouTube.json
@@ -1,0 +1,14 @@
+{
+  "name": "YouTube",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/youtube.com.xml",
+  "documents": {
+    "Terms of Service": {
+      "fetch": "https://www.youtube.com/t/terms",
+      "select": "div#article-container"
+    },
+    "Privacy Policy": {
+      "fetch": "https://policies.google.com/privacy",
+      "select": "div[role=\"article\"]"
+    }
+  }
+}

--- a/services/Zoosk.json
+++ b/services/Zoosk.json
@@ -1,0 +1,10 @@
+{
+  "name": "Zoosk",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/zoosk.com.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://docviewer.zoosk.com/legal-privacy-en.html",
+      "select": "div.document-container"
+    }
+  }
+}

--- a/services/phpBB.json
+++ b/services/phpBB.json
@@ -1,0 +1,10 @@
+{
+  "name": "phpBB",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/940c8d2ffb356473d324a3e0830723f39779de0c/rules/phpbb.com.xml",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://www.phpbb.com/community/ucp.php?mode=privacy",
+      "select": "div.content"
+    }
+  }
+}


### PR DESCRIPTION
These service declarations were imported using `scripts/tosback-import.js`.
I ran `npm run validate` and removed the declarations for which validation failed.
Issues: 
* [ ] some service names contain spaces and/or `.com` extensions. What is the common practice for choosing service names? -> https://github.com/ambanum/CGUs/issues/106
* [ ] I'll run the crawler a few times with these services and see if I get any false positives.