### PR TITLE
An example rule to add

### DIFF
--- a/services/AmazonAlexa.json
+++ b/services/AmazonAlexa.json
@@ -1,0 +1,10 @@
+{
+  "name": "AmazonAlexa",
+  "importedFrom": "https://github.com/tosdr/tosback2/blob/b10b738ce7f5fc18b90c513c4db360f728348058/rules/amazon.com.xml",
+  "documents": {
+    "Terms of Service": {
+      "fetch": "https://www.amazon.com/gp/help/customer/display.html?nodeId=201809740",
+      "select": "div.help-content"
+    }
+  }
+}


### PR DESCRIPTION
In tosback2 we have for instance "Alexa Terms of Service" under amazon.com.xml.
I translated those to "Terms of Service" of "AmazonAlexa.json".

Here are a few examples of how my script creates them now. Note that they contain the selectors translated from xpath, but when creating the imported versions, i'm using 'body' as the selector.