### PR TITLE
Drop Facebook redirections in Facebook.filters.js

### DIFF
--- a/services/Facebook.filters.js
+++ b/services/Facebook.filters.js
@@ -20,7 +20,7 @@ export function cleanUrls(document) {
   const links = document.querySelectorAll('[href*="https://l.facebook.com/l.php?"],[href*="http://l.facebook.com/l.php?"]');
 
   links.forEach(link => {
-    link.href = link.href.replace(/&h=\S*/, '');
+    link.href = decodeURIComponent(link.href.replace(/&h=\S*/, '').replace(/(\S*)\?u=(\S*)/, '$2'));
   });
 }
 


### PR DESCRIPTION
Hi,

Was keeping the `http://l.facebook.com/l.php` part on purpose? It seems we can completely get rid of the redirection with an extra step of regex matching, which might help lowering the noise.

In particular, considering https://github.com/ambanum/CGUs-versions/commit/4f66b53ee, after this change it would reduce to a simple HTTP / HTTPS noise which could be taken into account globally.

Best,