### PR TITLE
Filter out country version blinking in Google Terms of Services

### DIFF
--- a/services/Google.filters.js
+++ b/services/Google.filters.js
@@ -4,3 +4,19 @@ export function removeUTMfromUrls(document) {
     link.href = link.href.replace(/utm_[^=]*=[^&]*[&]{0,1}/g, '');
   });
 }
+
+export function removeCountryVersion(document) {
+  // Remove "country version" link at top of the page
+  document.querySelector('a[data-name="country-version"]').parentNode.remove();
+
+  // Remove all the "country version" section in the CGUs
+  const countryVersionTitle = document.querySelector('#footnote-country-version');
+  const disclaimerTitle = document.querySelector('#footnote-disclaimer');
+
+  let node = countryVersionTitle;
+  while (node !== disclaimerTitle.previousSibling) {
+    const next = node.nextSibling;
+    node.remove();
+    node = next;
+  }
+}

--- a/services/Google.filters.js
+++ b/services/Google.filters.js
@@ -4,19 +4,3 @@ export function removeUTMfromUrls(document) {
     link.href = link.href.replace(/utm_[^=]*=[^&]*[&]{0,1}/g, '');
   });
 }
-
-export function removeCountryVersion(document) {
-  // Remove "country version" link at top of the page
-  document.querySelector('a[data-name="country-version"]').parentNode.remove();
-
-  // Remove all the "country version" section in the CGUs
-  const countryVersionTitle = document.querySelector('#footnote-country-version');
-  const disclaimerTitle = document.querySelector('#footnote-disclaimer');
-
-  let node = countryVersionTitle;
-  while (node !== disclaimerTitle.previousSibling) {
-    const next = node.nextSibling;
-    node.remove();
-    node = next;
-  }
-}

--- a/services/Google.json
+++ b/services/Google.json
@@ -14,7 +14,17 @@
       "filter": [
         "removeUTMfromUrls"
       ],
-      "select": "div[role=article]"
+      "select": "div[role=article]",
+      "remove": [
+        {
+          "startBefore": "a[data-name='country-version']",
+          "endBefore": "#whats-covered"
+        },
+        {
+          "startBefore": "#footnote-country-version",
+          "endBefore": "#footnote-disclaimer"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Hi,

I guess this should do the trick to filter out all "country version" elements blinking in Google Terms of Services. Sadly, there is no narrow selector which could be used to filter out this text, hence I have to remove the full section of the ToS by looking at section titles.

I did not find any more robust way so far, I'm welcoming any idea on this.

Best,