### PR TITLE
Run CI on every push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,10 @@
-name: Test & Deploy
+name: Deploy
 
 on:
   push:
     branches: [ master ]
 
 env:
-  SENDINBLUE_API_KEY: ${{ secrets.SENDINBLUE_API_KEY }}
   ANSIBLE_VAULT_PASSWORD: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}
 
 jobs:
@@ -19,22 +18,15 @@ jobs:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
     - run: git checkout HEAD
-    - name: Use Node.js
-      uses: actions/setup-node@v1
-      with:
-        node-version: '12.17'
     - name: Install SSH key
       uses: shimataro/ssh-key-action@v2
       with:
         key: ${{ secrets.SSH_KEY }}
         known_hosts: ${{ secrets.KNOWN_HOSTS }}
     - run: echo "$ANSIBLE_VAULT_PASSWORD" > vault.key
-    - run: npm ci
     - run: |
         git config --global user.name 'AmbNum Bot'
         git config --global user.email 'ambnum.bot@disinfo.quaidorsay.fr'
-    - run: npm run validate:schema
-    - run: npm test
     - run: pip install --upgrade setuptools
     - run: pip install ansible==2.9.11
     - run: ansible-playbook ops/site.yml -i ops/inventories/production.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches: [ master ]
 
-env:
-  ANSIBLE_VAULT_PASSWORD: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}
-
 jobs:
   deploy:
 
@@ -23,7 +20,7 @@ jobs:
       with:
         key: ${{ secrets.SSH_KEY }}
         known_hosts: ${{ secrets.KNOWN_HOSTS }}
-    - run: echo "$ANSIBLE_VAULT_PASSWORD" > vault.key
+    - run: echo "${{ secrets.ANSIBLE_VAULT_PASSWORD }}" > vault.key
     - run: |
         git config --global user.name 'AmbNum Bot'
         git config --global user.email 'ambnum.bot@disinfo.quaidorsay.fr'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: Test
 
-on:
-  pull_request:
-    branches: [ master ]
+on: [ push, pull_request ]
 
 env:
   SENDINBLUE_API_KEY: ${{ secrets.SENDINBLUE_API_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,6 @@ name: Test
 
 on: [ push, pull_request ]
 
-env:
-  SENDINBLUE_API_KEY: ${{ secrets.SENDINBLUE_API_KEY }}
-
 jobs:
   test:
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start:scheduler:prod": "NODE_ENV=production node src/index.js --schedule",
     "refilter": "node src/index.js --refilter-only",
     "setup": "node scripts/setup.js",
-    "lint": "./node_modules/eslint/bin/eslint.js test src services",
+    "lint": "./node_modules/.bin/eslint test src services",
     "posttest": "npm run lint",
     "test": "NODE_ENV=test mocha --file './test/helper.js' --recursive \"./src/**/*.test.js\"",
     "test:debug": "NODE_ENV=test mocha --file './test/helper.js' --recursive \"./src/**/*.test.js\" --inspect-brk --exit",


### PR DESCRIPTION
To get earlier feedback and to allow for silent CI tests (as opposed to always having to open a pull request), this changeset sets the `test` workflow to run on every push instead of running only when PRs are opened against `master`.

It also separates running tests and deploying, ensuring the bijection between a commit to `master` and a version in production, making the assumption that pushes to `master` have always be checked (or in any case that the person pushing takes the responsibility for it). This works well when combined with tests being run on every push and branch protection set up to enforce tests passing before a push to `master` is allowed.