### PR TITLE
Allow query params in URLs for PDF files

### DIFF
--- a/scripts/validation/service.schema.js
+++ b/scripts/validation/service.schema.js
@@ -59,7 +59,7 @@ const schema = {
       properties: {
         fetch: {
           type: 'string',
-          pattern: '^https?:\/\/.+\.[pP][dD][fF]\??',
+          pattern: '^https?://.+\.[pP][dD][fF](\\?.+)?$',
           description: 'The URL where the document can be found'
         },
       },

--- a/scripts/validation/service.schema.js
+++ b/scripts/validation/service.schema.js
@@ -59,7 +59,7 @@ const schema = {
       properties: {
         fetch: {
           type: 'string',
-          pattern: '^https?://.+\.[pP][dD][fF]$',
+          pattern: '^https?:\/\/.+\.[pP][dD][fF]\??',
           description: 'The URL where the document can be found'
         },
       },


### PR DESCRIPTION
Fix the schema validation for PDF documents with query params in the URL added in PR #170.