### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: '12.17'
+        node-version: 12.x
     - run: npm ci
     - run: |
         git config --global user.name 'AmbNum Bot'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.sha }}
-    - run: git checkout HEAD
-    - run: git fetch origin master:master
     - name: Use Node.js
       uses: actions/setup-node@v1
       with:
@@ -23,5 +18,4 @@ jobs:
         git config --global user.name 'AmbNum Bot'
         git config --global user.email 'ambnum.bot@disinfo.quaidorsay.fr'
     - run: npm run validate:schema
-    - run: npm run validate:modified
     - run: npm test

--- a/.github/workflows/validate_modified_services.yml
+++ b/.github/workflows/validate_modified_services.yml
@@ -1,0 +1,26 @@
+name: Validate modified services
+
+on:
+  push:
+    branches-ignore:
+      - master  # by definition, there are no modified services on the master branch
+  pull_request:
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha }}
+    - run: git checkout HEAD
+    - run: git fetch origin master:master
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: '12.17'
+    - run: npm ci
+    - run: npm run validate:modified

--- a/.github/workflows/validate_modified_services.yml
+++ b/.github/workflows/validate_modified_services.yml
@@ -21,6 +21,6 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: '12.17'
+        node-version: 12.x
     - run: npm ci
     - run: npm run validate:modified


### PR DESCRIPTION
Following #160, we discovered that testing modified services failed on `master` because `git fetch origin master:master`, which is needed when working on a different branch, quite logically [fails](https://github.com/ambanum/CGUs/runs/1258267884?check_suite_focus=true) when the current branch is `master`.

This changes splits the code testing and the modified services validation in two separate workflows, which also has the added benefit of better readability. The services validation workflow is triggered only when the branch is not `master`, which by definition never has modified services.

I also made sure to test with the latest Node 12 version instead of sticking to Node 12.17 (for example, this workflow can now [run on Node 12.18](https://github.com/ambanum/CGUs/actions/runs/308362645)).

I considered creating a `.env.test` file instead of manually setting the git username and email, but running a `mv` command would not be cross-platform and #167 shows we should consider other platforms.