### PR TITLE
Remove redundant and unused document types

### DIFF
--- a/services/AdSense.json
+++ b/services/AdSense.json
@@ -5,11 +5,6 @@
       "fetch": "https://www.google.com/adsense/tc/2018/UnitedKingdom.html",
       "select": "body"
     },
-    "Program Policies": {
-      "fetch": "https://support.google.com/adsense/answer/48182",
-      "select": ".article-container",
-      "remove": ".action-button, .zippy"
-    },
     "Parent Organization Privacy Policy": {
       "fetch": "https://policies.google.com/privacy?hl=en-GB",
       "filter": [

--- a/services/Google Ads.json
+++ b/services/Google Ads.json
@@ -13,7 +13,7 @@
       "select": "div[role=article]",
       "remove": ".KMMDve, .TL2alc, img[src$='.svg']"
     },
-    "Program Policies": {
+    "Acceptable Use Policy": {
       "fetch": "https://support.google.com/adspolicy/answer/6008942",
       "select": ".article-container"
     },

--- a/src/app/types.json
+++ b/src/app/types.json
@@ -52,14 +52,14 @@
     "commitment": {
       "writer": "service provider",
       "audience": "end user",
-      "object": "acceptable usage"
+      "object": "acceptable and unacceptable usage"
     }
   },
   "Restricted Use Policy": {
     "commitment": {
       "writer": "service provider",
       "audience": "end user",
-      "object": "restricted usage"
+      "object": "restrictions on specific usage"
     }
   },
   "Commercial Terms": {

--- a/src/app/types.json
+++ b/src/app/types.json
@@ -157,7 +157,7 @@
     "commitment": {
       "writer": "service provider",
       "audience": "end user",
-      "object": "connecting your account to other services"
+      "object": "connecting user account to other services"
     }
   },
   "Vulnerability Disclosure Policy": {
@@ -165,20 +165,6 @@
       "writer": "service provider",
       "audience": "vulnerability reporter",
       "object": "how to report a security vulnerability or issue"
-    }
-  },
-  "Legal Information": {
-    "commitment": {
-      "writer": "service provider",
-      "audience": "end user",
-      "object": "all term, conditions, and policies related to the use of the service"
-    }
-  },
-  "Program Policies": {
-    "commitment": {
-      "writer": "service provider",
-      "audience": "program users",
-      "object": "program usage"
     }
   }
 }


### PR DESCRIPTION
“Legal Information” is not used anywhere, and “Program Policies” is too generic.

This might impact some of the import work, so would need a review from @michielbdejong.