### PR TITLE
fix: install of forever not working and breaking deploy

### DIFF
--- a/ops/roles/infra/tasks/main.yml
+++ b/ops/roles/infra/tasks/main.yml
@@ -21,10 +21,7 @@
   command: npm install -g npm
 
 - name: Install forever
-  npm:
-    name: forever
-    global: yes
-    production: yes
+  npm: name=forever global=yes state=present production=yes # https://github.com/geerlingguy/ansible-for-devops/issues/23
 
 - name: Add GitHub SSH key
   copy:


### PR DESCRIPTION
Deploy breaks with

```
TASK [infra : Install forever] *************************************************`
`
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ValueError: No JSON object could be decoded
```