### PR TITLE
fix: prevent CI github tests on windows to fail with timeout

### DIFF
--- a/src/app/fetcher/fullDomFetcher.js
+++ b/src/app/fetcher/fullDomFetcher.js
@@ -17,6 +17,7 @@ export default async function fetch(url, cssSelectors) {
   try {
     browser = await puppeteer.launch({ headless: true });
     page = await browser.newPage();
+    await page.setDefaultNavigationTimeout(60000); // 60s
 
     response = await page.goto(url);
     const statusCode = response.status();


### PR DESCRIPTION
Add a max timeout of 60s